### PR TITLE
Add 'Notification count if non zero'

### DIFF
--- a/resources/settings/settings.xml
+++ b/resources/settings/settings.xml
@@ -368,6 +368,7 @@
         <settingConfig type="list">
             <listEntry value="-2">Hidden</listEntry>
             <listEntry value="36">Notification count</listEntry>
+            <listEntry value="136">Notification count if not zero</listEntry>
             <listEntry value="31">Week number</listEntry>
             <listEntry value="34">Battery percentage</listEntry>
             <listEntry value="35">Battery days remaining</listEntry>

--- a/source/Segment34View.mc
+++ b/source/Segment34View.mc
@@ -1412,11 +1412,20 @@ class Segment34View extends WatchUi.WatchFace {
     }
 
     hidden function getValueByTypeWithUnit(complicationType as Number, width as Number) as String {
+        var hideIfZero = false;
+        if (complicationType == 136) {
+            complicationType = 36;
+            hideIfZero = true;
+        }
         var unit = getUnitByType(complicationType);
         if (unit.length() > 0) {
             unit = " " + unit;
         }
-        return getValueByType(complicationType, width) + unit;
+        var val = getValueByType(complicationType, width);
+        if (hideIfZero && val.equals("0")) {
+            return "";
+        }
+        return val + unit;
     }
 
     hidden function getUnitByType(complicationType) as String {


### PR DESCRIPTION
A recent commit changed the previous behavior of only showing the notification count if non zero.
It's very handy to have something show up only if notifications are available- it's very quick to look at the watch and see if there's nothing or something.

This PR adds an option to show the count only if non zero.